### PR TITLE
ブログ 初回に401エラーとなるのを防ぐ

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["embla", "GAID", "instgrm", "ouchi", "sonner"]
+  "cSpell.words": ["embla", "GAID", "instgrm", "ouchi", "sonner", "SUPABASE"]
 }

--- a/frontend/app/(main)/blogs/[blogId]/page.tsx
+++ b/frontend/app/(main)/blogs/[blogId]/page.tsx
@@ -23,8 +23,8 @@ export async function generateMetadata({
   }
 
   return {
-    title: data.metadata.metaTitle || "ブログ詳細",
-    description: data.metadata.metaDescription || "ブログ詳細ページです。",
+    title: data.metadata?.metaTitle || "ブログ詳細",
+    description: data.metadata?.metaDescription || "ブログ詳細ページです。",
     openGraph: {
       images: [data.coverImage],
     },

--- a/frontend/app/(main)/blogs/[blogId]/page.tsx
+++ b/frontend/app/(main)/blogs/[blogId]/page.tsx
@@ -36,7 +36,13 @@ export async function generateMetadata({
  */
 async function getBlogById(blogId: string) {
   try {
-    const response = await fetch(`${STRAPI_API_URL}/api/blogs/${blogId}`);
+    const response = await fetch(`${STRAPI_API_URL}/api/blogs/${blogId}`, {
+      method: "GET",
+      credentials: "omit",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
 
     // レスポンス失敗
     if (!response.ok) {

--- a/frontend/app/(main)/blogs/page.tsx
+++ b/frontend/app/(main)/blogs/page.tsx
@@ -11,6 +11,7 @@ const getBlogs = async () => {
   try {
     const response = await fetch(`${STRAPI_API_URL}/api/blogs`, {
       method: "GET",
+      credentials: "omit",
       headers: {
         "Content-Type": "application/json",
       },

--- a/frontend/types/blog/blogTypes.ts
+++ b/frontend/types/blog/blogTypes.ts
@@ -36,7 +36,7 @@ interface Blog {
   /** 最終更新日時 */
   updatedAt: string;
   /** メタデータ */
-  metadata: Metadata;
+  metadata: Metadata | null;
 }
 
 export { type BlogData, type Blog };

--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -35,7 +35,7 @@ export default [
         "http://localhost:3000",
         "http://127.0.0.1:3000",
       ], // 許可するフロントエンドのURL
-      methods: ["GET", "POST", "PUT", "DELETE"], // 許可するHTTPメソッド
+      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"], // 許可するHTTPメソッド
       allowedHeaders: ["Content-Type", "Authorization"], // 許可するヘッダー
     },
   },


### PR DESCRIPTION
## 全体

- [x] 全体の動作確認は完了しているか
- [x] develop へのマージリクエストとなっているか

## frontend

- [x] `npm run build` を実行しエラーは出ていないか

## strapi

- [x] `npm run build`を実行しエラーは出ていないか

## 概要

<!--　
(例)　ブログ一覧・詳細ページ実装
-->

初回リクエスト時に401エラーとなり、認証をつけていないのに認証に失敗したことになってしまうため回避。
- credentials: "omit"を追加
- middlewareのmethodsに"OPTIONS"を追加

<img width="1438" alt="スクリーンショット 0007-04-06 13 53 20" src="https://github.com/user-attachments/assets/a6e1a232-bb8f-4736-9cc2-f848050155fc" />


## UI Before / After
なし
<!-- UI や振る舞いが変わる場合は before / after のスクショや動画を共有する -->

## 残作業・課題
なし
<!--
(例)　
・フィルター機能未実装
・〇〇について解決したい #1 （ISSUESのリンクを貼る等）
 -->

## 補足
なし
<!--　あれば補足　-->
