### PR TITLE
パス名もページ名もミートアップだったので、テーブルとAPIのエンドポイントをeventからmeetupにrename

### DIFF
--- a/strapi/package-lock.json
+++ b/strapi/package-lock.json
@@ -7014,7 +7014,7 @@
         "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fss": "~2.3.2"
       }
     },
     "node_modules/chownr": {

--- a/strapi/src/api/event-category/controllers/event-category.ts
+++ b/strapi/src/api/event-category/controllers/event-category.ts
@@ -1,7 +1,0 @@
-/**
- * event-category controller
- */
-
-import { factories } from '@strapi/strapi'
-
-export default factories.createCoreController('api::event-category.event-category');

--- a/strapi/src/api/event-category/routes/event-category.ts
+++ b/strapi/src/api/event-category/routes/event-category.ts
@@ -1,7 +1,0 @@
-/**
- * event-category router
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::event-category.event-category');

--- a/strapi/src/api/event-category/services/event-category.ts
+++ b/strapi/src/api/event-category/services/event-category.ts
@@ -1,7 +1,0 @@
-/**
- * event-category service
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreService('api::event-category.event-category');

--- a/strapi/src/api/event-organizer/controllers/event-organizer.ts
+++ b/strapi/src/api/event-organizer/controllers/event-organizer.ts
@@ -1,7 +1,0 @@
-/**
- * event-organizer controller
- */
-
-import { factories } from '@strapi/strapi'
-
-export default factories.createCoreController('api::event-organizer.event-organizer');

--- a/strapi/src/api/event-organizer/routes/event-organizer.ts
+++ b/strapi/src/api/event-organizer/routes/event-organizer.ts
@@ -1,7 +1,0 @@
-/**
- * event-organizer router
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::event-organizer.event-organizer');

--- a/strapi/src/api/event-organizer/services/event-organizer.ts
+++ b/strapi/src/api/event-organizer/services/event-organizer.ts
@@ -1,7 +1,0 @@
-/**
- * event-organizer service
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreService('api::event-organizer.event-organizer');

--- a/strapi/src/api/event/controllers/event.ts
+++ b/strapi/src/api/event/controllers/event.ts
@@ -1,7 +1,0 @@
-/**
- * event controller
- */
-
-import { factories } from '@strapi/strapi'
-
-export default factories.createCoreController('api::event.event');

--- a/strapi/src/api/event/routes/event.ts
+++ b/strapi/src/api/event/routes/event.ts
@@ -1,7 +1,0 @@
-/**
- * event router
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::event.event');

--- a/strapi/src/api/event/services/event.ts
+++ b/strapi/src/api/event/services/event.ts
@@ -1,7 +1,0 @@
-/**
- * event service
- */
-
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreService('api::event.event');

--- a/strapi/src/api/meetup-category/content-types/meetup-category/schema.json
+++ b/strapi/src/api/meetup-category/content-types/meetup-category/schema.json
@@ -1,10 +1,11 @@
 {
   "kind": "collectionType",
-  "collectionName": "event_categories",
+  "collectionName": "meetup_categories",
   "info": {
-    "singularName": "event-category",
-    "pluralName": "event-categories",
-    "displayName": "Event Category"
+    "singularName": "meetup-category",
+    "pluralName": "meetup-categories",
+    "displayName": "Meetup Category",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -19,11 +20,11 @@
       "type": "string",
       "required": true
     },
-    "events": {
+    "meetups": {
       "type": "relation",
       "relation": "manyToMany",
-      "target": "api::event.event",
-      "mappedBy": "categories"
+      "target": "api::meetup.meetup",
+      "inversedBy": "categories"
     }
   }
 }

--- a/strapi/src/api/meetup-category/controllers/meetup-category.ts
+++ b/strapi/src/api/meetup-category/controllers/meetup-category.ts
@@ -1,0 +1,9 @@
+/**
+ * meetup-category controller
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreController(
+  "api::meetup-category.meetup-category"
+);

--- a/strapi/src/api/meetup-category/routes/meetup-category.ts
+++ b/strapi/src/api/meetup-category/routes/meetup-category.ts
@@ -1,0 +1,9 @@
+/**
+ * meetup-category router
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreRouter(
+  "api::meetup-category.meetup-category"
+);

--- a/strapi/src/api/meetup-category/services/meetup-category.ts
+++ b/strapi/src/api/meetup-category/services/meetup-category.ts
@@ -1,0 +1,9 @@
+/**
+ * meetup-category service
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreService(
+  "api::meetup-category.meetup-category"
+);

--- a/strapi/src/api/meetup-organizer/content-types/meetup-organizer/schema.json
+++ b/strapi/src/api/meetup-organizer/content-types/meetup-organizer/schema.json
@@ -1,10 +1,11 @@
 {
   "kind": "collectionType",
-  "collectionName": "event_organizers",
+  "collectionName": "meetup_organizers",
   "info": {
-    "singularName": "event-organizer",
-    "pluralName": "event-organizers",
-    "displayName": "Event Organizer"
+    "singularName": "meetup-organizer",
+    "pluralName": "meetup-organizers",
+    "displayName": "Meetup Organizer",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -16,14 +17,13 @@
       "required": true
     },
     "avatar": {
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos",
-        "audios"
-      ],
       "type": "media",
-      "multiple": false
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images", "files", "videos", "audios"]
+    },
+    "description": {
+      "type": "text"
     },
     "email": {
       "type": "email",
@@ -44,13 +44,13 @@
     "homepageUrl": {
       "type": "string"
     },
-    "description": {
-      "type": "text"
+    "youtubeUrl": {
+      "type": "string"
     },
-    "events": {
+    "meetups": {
       "type": "relation",
       "relation": "oneToMany",
-      "target": "api::event.event",
+      "target": "api::meetup.meetup",
       "mappedBy": "organizer"
     }
   }

--- a/strapi/src/api/meetup-organizer/controllers/meetup-organizer.ts
+++ b/strapi/src/api/meetup-organizer/controllers/meetup-organizer.ts
@@ -1,0 +1,9 @@
+/**
+ * meetup-organizer controller
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreController(
+  "api::meetup-organizer.meetup-organizer"
+);

--- a/strapi/src/api/meetup-organizer/routes/meetup-organizer.ts
+++ b/strapi/src/api/meetup-organizer/routes/meetup-organizer.ts
@@ -1,0 +1,9 @@
+/**
+ * meetup-organizer router
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreRouter(
+  "api::meetup-organizer.meetup-organizer"
+);

--- a/strapi/src/api/meetup-organizer/services/meetup-organizer.ts
+++ b/strapi/src/api/meetup-organizer/services/meetup-organizer.ts
@@ -1,0 +1,9 @@
+/**
+ * meetup-organizer service
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreService(
+  "api::meetup-organizer.meetup-organizer"
+);

--- a/strapi/src/api/meetup/content-types/meetup/schema.json
+++ b/strapi/src/api/meetup/content-types/meetup/schema.json
@@ -1,10 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "events",
+  "collectionName": "meetups",
   "info": {
-    "singularName": "event",
-    "pluralName": "events",
-    "displayName": "Event",
+    "singularName": "meetup",
+    "pluralName": "meetups",
+    "displayName": "Meetup",
     "description": ""
   },
   "options": {
@@ -26,7 +26,11 @@
       "unique": false,
       "default": "全員"
     },
-    "datetime": {
+    "startDatetime": {
+      "type": "datetime",
+      "required": true
+    },
+    "endDatetime": {
       "type": "datetime",
       "required": true
     },
@@ -56,24 +60,7 @@
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos",
-        "audios"
-      ]
-    },
-    "organizer": {
-      "type": "relation",
-      "relation": "manyToOne",
-      "target": "api::event-organizer.event-organizer",
-      "inversedBy": "events"
-    },
-    "categories": {
-      "type": "relation",
-      "relation": "manyToMany",
-      "target": "api::event-category.event-category",
-      "inversedBy": "events"
+      "allowedTypes": ["images", "files", "videos", "audios"]
     },
     "applyMethod": {
       "type": "string",
@@ -83,6 +70,18 @@
       "type": "component",
       "repeatable": true,
       "component": "common.faq"
+    },
+    "organizer": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::meetup-organizer.meetup-organizer",
+      "inversedBy": "meetups"
+    },
+    "categories": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::meetup-category.meetup-category",
+      "mappedBy": "meetups"
     }
   }
 }

--- a/strapi/src/api/meetup/controllers/meetup.ts
+++ b/strapi/src/api/meetup/controllers/meetup.ts
@@ -1,0 +1,46 @@
+/**
+ * meetup controller
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreController(
+  "api::meetup.meetup",
+  ({ strapi }) => ({
+    async find(ctx) {
+      ctx.query = {
+        ...ctx.query,
+        populate: {
+          image: { fields: ["url"] },
+        },
+      };
+      return await super.find(ctx);
+    },
+
+    async findOne(ctx) {
+      const documentId = ctx.params.id;
+
+      const entity = await strapi.documents("api::meetup.meetup").findOne({
+        documentId,
+        populate: {
+          image: { fields: ["url"] },
+          categories: true,
+          faq: true,
+          organizer: {
+            populate: {
+              avatar: {
+                fields: ["url"],
+              },
+            },
+          },
+        },
+      });
+
+      if (!entity) {
+        return ctx.notFound("該当するブログが見つかりません");
+      }
+
+      return entity;
+    },
+  })
+);

--- a/strapi/src/api/meetup/routes/meetup.ts
+++ b/strapi/src/api/meetup/routes/meetup.ts
@@ -1,0 +1,7 @@
+/**
+ * meetup router
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreRouter("api::meetup.meetup");

--- a/strapi/src/api/meetup/services/meetup.ts
+++ b/strapi/src/api/meetup/services/meetup.ts
@@ -1,0 +1,7 @@
+/**
+ * meetup service
+ */
+
+import { factories } from "@strapi/strapi";
+
+export default factories.createCoreService("api::meetup.meetup");

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -510,127 +510,6 @@ export interface ApiBlogBlog extends Struct.CollectionTypeSchema {
   };
 }
 
-export interface ApiEventCategoryEventCategory
-  extends Struct.CollectionTypeSchema {
-  collectionName: 'event_categories';
-  info: {
-    displayName: 'Event Category';
-    pluralName: 'event-categories';
-    singularName: 'event-category';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    categoryId: Schema.Attribute.String & Schema.Attribute.Required;
-    categoryName: Schema.Attribute.String & Schema.Attribute.Required;
-    createdAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    events: Schema.Attribute.Relation<'manyToMany', 'api::event.event'>;
-    locale: Schema.Attribute.String & Schema.Attribute.Private;
-    localizations: Schema.Attribute.Relation<
-      'oneToMany',
-      'api::event-category.event-category'
-    > &
-      Schema.Attribute.Private;
-    publishedAt: Schema.Attribute.DateTime;
-    updatedAt: Schema.Attribute.DateTime;
-    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-  };
-}
-
-export interface ApiEventOrganizerEventOrganizer
-  extends Struct.CollectionTypeSchema {
-  collectionName: 'event_organizers';
-  info: {
-    displayName: 'Event Organizer';
-    pluralName: 'event-organizers';
-    singularName: 'event-organizer';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    avatar: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    createdAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    description: Schema.Attribute.Text;
-    email: Schema.Attribute.Email & Schema.Attribute.Required;
-    events: Schema.Attribute.Relation<'oneToMany', 'api::event.event'>;
-    homepageUrl: Schema.Attribute.String;
-    instagramUrl: Schema.Attribute.String;
-    locale: Schema.Attribute.String & Schema.Attribute.Private;
-    localizations: Schema.Attribute.Relation<
-      'oneToMany',
-      'api::event-organizer.event-organizer'
-    > &
-      Schema.Attribute.Private;
-    name: Schema.Attribute.String & Schema.Attribute.Required;
-    phoneNumber: Schema.Attribute.String;
-    publishedAt: Schema.Attribute.DateTime;
-    tiktokUrl: Schema.Attribute.String;
-    updatedAt: Schema.Attribute.DateTime;
-    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    xUrl: Schema.Attribute.String;
-  };
-}
-
-export interface ApiEventEvent extends Struct.CollectionTypeSchema {
-  collectionName: 'events';
-  info: {
-    description: '';
-    displayName: 'Event';
-    pluralName: 'events';
-    singularName: 'event';
-  };
-  options: {
-    draftAndPublish: true;
-  };
-  attributes: {
-    applyMethod: Schema.Attribute.String & Schema.Attribute.Required;
-    categories: Schema.Attribute.Relation<
-      'manyToMany',
-      'api::event-category.event-category'
-    >;
-    createdAt: Schema.Attribute.DateTime;
-    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-    datetime: Schema.Attribute.DateTime & Schema.Attribute.Required;
-    description: Schema.Attribute.RichText & Schema.Attribute.Required;
-    entryFee: Schema.Attribute.Decimal &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<0>;
-    entryFeeDescription: Schema.Attribute.Text;
-    faq: Schema.Attribute.Component<'common.faq', true>;
-    image: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
-    isOnline: Schema.Attribute.Boolean &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<false>;
-    locale: Schema.Attribute.String & Schema.Attribute.Private;
-    localizations: Schema.Attribute.Relation<'oneToMany', 'api::event.event'> &
-      Schema.Attribute.Private;
-    maxParticipant: Schema.Attribute.Integer;
-    organizer: Schema.Attribute.Relation<
-      'manyToOne',
-      'api::event-organizer.event-organizer'
-    >;
-    placeAddress: Schema.Attribute.String;
-    placeName: Schema.Attribute.String;
-    publishedAt: Schema.Attribute.DateTime;
-    targetParticipant: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<'\u5168\u54E1'>;
-    title: Schema.Attribute.String & Schema.Attribute.Required;
-    updatedAt: Schema.Attribute.DateTime;
-    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
-  };
-}
-
 export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
   collectionName: 'globals';
   info: {
@@ -657,6 +536,134 @@ export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
     publishedAt: Schema.Attribute.DateTime;
     siteDescription: Schema.Attribute.Text & Schema.Attribute.Required;
     siteName: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiMeetupCategoryMeetupCategory
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'meetup_categories';
+  info: {
+    description: '';
+    displayName: 'Meetup Category';
+    pluralName: 'meetup-categories';
+    singularName: 'meetup-category';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    categoryId: Schema.Attribute.String & Schema.Attribute.Required;
+    categoryName: Schema.Attribute.String & Schema.Attribute.Required;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::meetup-category.meetup-category'
+    > &
+      Schema.Attribute.Private;
+    meetups: Schema.Attribute.Relation<'manyToMany', 'api::meetup.meetup'>;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiMeetupOrganizerMeetupOrganizer
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'meetup_organizers';
+  info: {
+    description: '';
+    displayName: 'Meetup Organizer';
+    pluralName: 'meetup-organizers';
+    singularName: 'meetup-organizer';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    avatar: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.Text;
+    email: Schema.Attribute.Email & Schema.Attribute.Required;
+    homepageUrl: Schema.Attribute.String;
+    instagramUrl: Schema.Attribute.String;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::meetup-organizer.meetup-organizer'
+    > &
+      Schema.Attribute.Private;
+    meetups: Schema.Attribute.Relation<'oneToMany', 'api::meetup.meetup'>;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    phoneNumber: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    tiktokUrl: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    xUrl: Schema.Attribute.String;
+    youtubeUrl: Schema.Attribute.String;
+  };
+}
+
+export interface ApiMeetupMeetup extends Struct.CollectionTypeSchema {
+  collectionName: 'meetups';
+  info: {
+    description: '';
+    displayName: 'Meetup';
+    pluralName: 'meetups';
+    singularName: 'meetup';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    applyMethod: Schema.Attribute.String & Schema.Attribute.Required;
+    categories: Schema.Attribute.Relation<
+      'manyToMany',
+      'api::meetup-category.meetup-category'
+    >;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.RichText & Schema.Attribute.Required;
+    endDatetime: Schema.Attribute.DateTime & Schema.Attribute.Required;
+    entryFee: Schema.Attribute.Decimal &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<0>;
+    entryFeeDescription: Schema.Attribute.Text;
+    faq: Schema.Attribute.Component<'common.faq', true>;
+    image: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    isOnline: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<false>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::meetup.meetup'
+    > &
+      Schema.Attribute.Private;
+    maxParticipant: Schema.Attribute.Integer;
+    organizer: Schema.Attribute.Relation<
+      'manyToOne',
+      'api::meetup-organizer.meetup-organizer'
+    >;
+    placeAddress: Schema.Attribute.String;
+    placeName: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    startDatetime: Schema.Attribute.DateTime & Schema.Attribute.Required;
+    targetParticipant: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'\u5168\u54E1'>;
+    title: Schema.Attribute.String & Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1176,10 +1183,10 @@ declare module '@strapi/strapi' {
       'api::author.author': ApiAuthorAuthor;
       'api::blog-category.blog-category': ApiBlogCategoryBlogCategory;
       'api::blog.blog': ApiBlogBlog;
-      'api::event-category.event-category': ApiEventCategoryEventCategory;
-      'api::event-organizer.event-organizer': ApiEventOrganizerEventOrganizer;
-      'api::event.event': ApiEventEvent;
       'api::global.global': ApiGlobalGlobal;
+      'api::meetup-category.meetup-category': ApiMeetupCategoryMeetupCategory;
+      'api::meetup-organizer.meetup-organizer': ApiMeetupOrganizerMeetupOrganizer;
+      'api::meetup.meetup': ApiMeetupMeetup;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
       'plugin::i18n.locale': PluginI18NLocale;


### PR DESCRIPTION
## 全体

- [x] 全体の動作確認は完了しているか
- [x] develop へのマージリクエストとなっているか

## frontend

- [-] `npm run build` を実行しエラーは出ていないか

## strapi

- [x] `npm run build`を実行しエラーは出ていないか

## 概要
パス名もページ名もミートアップだったので、テーブルとAPIのエンドポイントeventからmeetupにrenameしました。

<!--　
(例)　ブログ一覧・詳細ページ実装
-->

## UI Before / After
strapiの修正のみのためなし。
<!-- UI や振る舞いが変わる場合は before / after のスクショや動画を共有する -->

## 残作業・課題
なし。
<!--
(例)　
・フィルター機能未実装
・〇〇について解決したい #1 （ISSUESのリンクを貼る等）
 -->

## 補足
なし。
<!--　あれば補足　-->
