### PR TITLE
add:Propertyカードリスト、共通コンポーネント（カードリスト・詳細ページ）、カテゴリーバー、ヘッダーへ最大幅の設定

### DIFF
--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -13,9 +13,11 @@ const MainLayout = ({
   return (
     <div className="min-w-screen">
       <Header />
-      <Categories />
       <main className="content-height z-0">
-        <Suspense fallback={<Loader />}>{children}</Suspense>
+        <Categories />
+        <div className="w-full mx-auto flex justify-center">
+          <Suspense fallback={<Loader />}>{children}</Suspense>
+        </div>
       </main>
       <Analytics />
       <Footer />

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -13,8 +13,8 @@ const MainLayout = ({
   return (
     <div className="min-w-screen">
       <Header />
+      <Categories />
       <main className="content-height z-0">
-        <Categories />
         <div className="w-full mx-auto flex justify-center">
           <Suspense fallback={<Loader />}>{children}</Suspense>
         </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -60,24 +60,18 @@
 }
 
 @layer components {
-  .iconLabelItem {
-    @apply mr-2 h-4 w-4;
-  }
+  /* 共通px */
   .base-px {
     @apply px-4 md:px-10 xl:px-20 2xl:px-0 w-full 2xl:max-w-[1436px];
   }
 
-  .base-py {
-    @apply py-4 md:py-10 xl:py-20;
+  /* 詳細画面用px */
+  .detailPage-base-px {
+    @apply px-4 sm:px-12 xl:px-32 2xl:px-12 w-full 2xl:max-w-[1436px];
   }
-
   /* ヘッダー、カテゴリーヘッダー、フッターの高さを引いたコンテンツの高さ */
   .content-height {
     @apply min-h-[calc(100vh-64px-80px-64px)] lg:min-h-[calc(100vh-80px-80px-68px)] z-0;
-  }
-
-  .propertyPageImage {
-    @apply w-full max-w-[1200px] h-[300px] sm:h-[450px] xl:h-[480px] bg-slate-300 relative mx-auto;
   }
 }
 
@@ -90,7 +84,8 @@
   }
 }
 
+/* インスタ埋め込みのwidth設定 */
 .instagram-media {
   min-width: 100% !important;
-  max-width: 400px !important;
+  max-width: 300px !important;
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -64,7 +64,8 @@
     @apply mr-2 h-4 w-4;
   }
   .base-px {
-    @apply px-4 md:px-10 xl:px-20;
+    /* @apply px-4 md:px-10 xl:px-20; */
+    @apply px-4 md:px-10 2xl:px-0 w-full 2xl:max-w-[1436px];
   }
 
   .base-py {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -64,8 +64,7 @@
     @apply mr-2 h-4 w-4;
   }
   .base-px {
-    /* @apply px-4 md:px-10 xl:px-20; */
-    @apply px-4 md:px-10 2xl:px-0 w-full 2xl:max-w-[1436px];
+    @apply px-4 md:px-10 xl:px-20 2xl:px-0 w-full 2xl:max-w-[1436px];
   }
 
   .base-py {

--- a/frontend/components/common/Categories.tsx
+++ b/frontend/components/common/Categories.tsx
@@ -38,6 +38,11 @@ export const CATEGORY_LIST: Category[] = [
     pathname: "/properties",
   },
   {
+    name: "おすすめブログ",
+    icon: Laptop,
+    pathname: "/blogs",
+  },
+  {
     name: "お仕事探し",
     icon: BriefcaseBusiness,
     pathname: "/jobs",
@@ -106,11 +111,6 @@ export const CATEGORY_LIST: Category[] = [
     name: "BLOOMニュース",
     icon: Flower2,
     pathname: "/bloom-news",
-  },
-  {
-    name: "おすすめブログ",
-    icon: Laptop,
-    pathname: "/blogs",
   },
 ] as const;
 /**
@@ -264,48 +264,51 @@ function Categories() {
     //     isFixed ? "fixed top-0 left-0 bg-white shadow-md" : ""
     //   }`}
     // >
-    <div className="relative base-px py-2 h-20">
-      <div className="overflow-hidden" ref={emblaRef}>
-        <div className="flex">
-          {CATEGORY_LIST.map((item, index) => (
-            <div
-              key={item.name}
-              ref={(el) => {
-                categoryRefs.current[item.pathname] = el;
-              }}
-              onClick={() => handleCategoryClick(item.pathname)}
-              className={`${index === 0 ? "ml-0" : "ml-2 lg:ml-3"} ${
-                index === CATEGORY_LIST.length - 1 ? "mr-0" : "mr-2 lg:mr-3"
-              }`}
-            >
-              <CategoryBox
-                icon={item.icon}
-                name={item.name}
-                pathname={item.pathname}
-                selected={pathname === item.pathname}
-              />
-            </div>
-          ))}
+    <div className="w-full flex justify-center">
+      <div className="relative base-px py-2 h-20  ">
+        {/* <div className="relative base-px py-2 h-20"> */}
+        <div className="overflow-hidden" ref={emblaRef}>
+          <div className="flex">
+            {CATEGORY_LIST.map((item, index) => (
+              <div
+                key={item.name}
+                ref={(el) => {
+                  categoryRefs.current[item.pathname] = el;
+                }}
+                onClick={() => handleCategoryClick(item.pathname)}
+                className={`${index === 0 ? "ml-0" : "ml-2 lg:ml-3"} ${
+                  index === CATEGORY_LIST.length - 1 ? "mr-0" : "mr-2 lg:mr-3"
+                }`}
+              >
+                <CategoryBox
+                  icon={item.icon}
+                  name={item.name}
+                  pathname={item.pathname}
+                  selected={pathname === item.pathname}
+                />
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
-      {/* スクロールボタン PCで表示 */}
-      <div className="hidden lg:block">
-        {prevBtnEnabled && (
-          <button
-            className="absolute left-10 xl:left-20 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
-            onClick={scrollPrev}
-          >
-            <ChevronLeft size={18} />
-          </button>
-        )}
-        {nextBtnEnabled && (
-          <button
-            className="absolute right-10 xl:right-20 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
-            onClick={scrollNext}
-          >
-            <ChevronRight size={18} />
-          </button>
-        )}
+        {/* スクロールボタン PCで表示 */}
+        <div className="hidden lg:block">
+          {prevBtnEnabled && (
+            <button
+              className="absolute left-10 xl:left-20 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
+              onClick={scrollPrev}
+            >
+              <ChevronLeft size={18} />
+            </button>
+          )}
+          {nextBtnEnabled && (
+            <button
+              className="absolute right-10 xl:right-20 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
+              onClick={scrollNext}
+            >
+              <ChevronRight size={18} />
+            </button>
+          )}
+        </div>
       </div>
     </div>
     // </div>

--- a/frontend/components/common/Categories.tsx
+++ b/frontend/components/common/Categories.tsx
@@ -266,7 +266,6 @@ function Categories() {
     // >
     <div className="w-full flex justify-center">
       <div className="relative base-px py-2 h-20  ">
-        {/* <div className="relative base-px py-2 h-20"> */}
         <div className="overflow-hidden" ref={emblaRef}>
           <div className="flex">
             {CATEGORY_LIST.map((item, index) => (

--- a/frontend/components/common/frame/DetailPageFrame.tsx
+++ b/frontend/components/common/frame/DetailPageFrame.tsx
@@ -20,12 +20,12 @@ function DetailPageFrame({
   className?: string;
 }) {
   return (
-    <div className="base-px flex flex-col items-center">
-      <div className={cn("sm:px-8 lg:px-20 xl:px-32 py-4", className)}>
+    <div className="max-w-screen flex flex-col items-center">
+      {detailHeaderList && (
+        <DetailPageHeader headerOptions={detailHeaderList} />
+      )}
+      <div className={cn("detailPage-base-px py-4", className)}>
         <BreadcrumbComponent pageName={pageName} />
-        {detailHeaderList && (
-          <DetailPageHeader headerOptions={detailHeaderList} />
-        )}
         {children}
       </div>
     </div>

--- a/frontend/components/common/frame/DetailPageFrame.tsx
+++ b/frontend/components/common/frame/DetailPageFrame.tsx
@@ -20,8 +20,8 @@ function DetailPageFrame({
   className?: string;
 }) {
   return (
-    <div className="w-full flex flex-col items-center">
-      <div className={cn("px-4 sm:px-12 lg:px-22 xl:px-32 py-4", className)}>
+    <div className="base-px flex flex-col items-center">
+      <div className={cn("sm:px-8 lg:px-20 xl:px-32 py-4", className)}>
         <BreadcrumbComponent pageName={pageName} />
         {detailHeaderList && (
           <DetailPageHeader headerOptions={detailHeaderList} />

--- a/frontend/components/common/frame/ListPageFrame.tsx
+++ b/frontend/components/common/frame/ListPageFrame.tsx
@@ -65,7 +65,7 @@ function ListPageFrame({
             <p>条件に一致する物件が見つかりませんでした。</p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-6 gap-2 sm:gap-4 lg:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-4 lg:gap-6">
             {cardArea}
           </div>
         )}

--- a/frontend/components/common/header/DetailPageHeader.tsx
+++ b/frontend/components/common/header/DetailPageHeader.tsx
@@ -147,15 +147,15 @@ function DetailPageHeader({
 
   return (
     <header
-      className={`fixed base-px top-0 left-0 right-0 h-14 bg-white transition-transform duration-300 ease-in-out z-50 ${
+      className={`fixed top-0 left-0 right-0 h-14 bg-white transition-transform duration-300 ease-in-out z-50 ${
         isVisible ? "translate-y-0 shadow-md" : "-translate-y-full"
       }`}
     >
-      <div className="mx-auto lg:px-12">
+      <div className="mx-auto detailPage-base-px">
         <nav>
           <ul
             ref={headerRef}
-            className="flex space-x-4 overflow-x-auto whitespace-nowrap items-center justify-start h-14"
+            className="flex space-x-6 overflow-x-auto whitespace-nowrap items-center justify-start h-14"
           >
             {headerOptions.map((item) => (
               <li key={item.id} className="inline-block">
@@ -220,7 +220,7 @@ function ScrollToSection({
     <button
       onClick={handleClick}
       data-section={dataSectionAttr}
-      className={`text-sm tracking-wider lg:text-base focus:outline-none whitespace-nowrap px-2 py-1 transition-colors duration-200 ${
+      className={`text-sm tracking-wider lg:text-base focus:outline-none whitespace-nowrap py-1 transition-colors duration-200 ${
         isActive ? "text-bloom-blue font-bold" : "text-bloom-gray"
       }`}
     >

--- a/frontend/components/common/loading/DetailPageSkeleton.tsx
+++ b/frontend/components/common/loading/DetailPageSkeleton.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
  */
 function DetailPageSkeleton() {
   return (
-    <div>
+    <div className="base-px">
       <Skeleton className="w-full h-64" />
       <div className="max-w-[1200px] lg:h-[60lvh] flex flex-col lg:flex-row mx-auto">
         <div className="w-full lg:w-[60%] py-8 lg:pr-2">

--- a/frontend/components/common/loading/DetailPageSkeleton.tsx
+++ b/frontend/components/common/loading/DetailPageSkeleton.tsx
@@ -4,11 +4,11 @@ import { Skeleton } from "@/components/ui/skeleton";
  */
 function DetailPageSkeleton() {
   return (
-    <div className="base-px">
+    <div className="detailPage-base-px">
       <Skeleton className="w-full h-64" />
       <div className="max-w-[1200px] lg:h-[60lvh] flex flex-col lg:flex-row mx-auto">
         <div className="w-full lg:w-[60%] py-8 lg:pr-2">
-          <Skeleton className="w-3/4 h-8 mb-4" />{" "}
+          <Skeleton className="w-3/4 h-8 mb-4" />
           <div className="space-y-4">
             <Skeleton className="w-full h-8" />
             <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
@@ -20,8 +20,8 @@ function DetailPageSkeleton() {
         </div>
         <div className="w-full lg:w-[40%] py-8 lg:pl-2">
           <div className="flex flex-col justify-between items-center bg-slate-100 rounded-lg p-2 lg:h-full h-[50lvh]">
-            <Skeleton className="w-full h-16 mb-4" />{" "}
-            <Skeleton className="w-full h-10" />{" "}
+            <Skeleton className="w-full h-16 mb-4" />
+            <Skeleton className="w-full h-10" />
           </div>
         </div>
       </div>

--- a/frontend/components/common/loading/ListPageSkeleton.tsx
+++ b/frontend/components/common/loading/ListPageSkeleton.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from "../../ui/skeleton";
  */
 function ListPageSkeleton() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 sm:gap-4 lg:gap-6 base-px py-10">
+    <div className="base-px grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-4 lg:gap-6 base-px py-10">
       {[...Array(30)].map((_, i) => (
         <div key={i} className="relative rounded-lg">
           {/* 画像エリア */}

--- a/frontend/components/features/blog/BlogDetail.tsx
+++ b/frontend/components/features/blog/BlogDetail.tsx
@@ -15,7 +15,7 @@ export default function BlogDetail({ data }: { data: Blog }) {
       className="flex flex-col items-center w-full lg:w-[75vw]"
       pageName={data.title}
     >
-      <div className="tracking-wider flex flex-col">
+      <div className="tracking-wider flex flex-col w-full">
         {/* 画像 */}
         <Image
           src={data.coverImage.url}

--- a/frontend/components/features/property/PropertyDetailContents.tsx
+++ b/frontend/components/features/property/PropertyDetailContents.tsx
@@ -87,7 +87,7 @@ export const PropertyImage = ({
 }) => {
   return (
     <div id="images">
-      <div className="propertyPageImage mt-2 flex flex-col rounded-lg">
+      <div className="max-w-full h-[300px] sm:h-[450px] xl:h-[480px] bg-slate-300 relative mt-2 flex flex-col rounded-lg">
         {imgUrl ? (
           <div>
             <Image

--- a/frontend/components/features/property/PropertyDetailContents.tsx
+++ b/frontend/components/features/property/PropertyDetailContents.tsx
@@ -41,7 +41,7 @@ export const SectionWrapper = ({
   return (
     <div
       id={id}
-      className={`pt-3 pb-8 sm:pt-5 sm:pb-10 border-b last:border-b-0 ${className}`}
+      className={`pt-3 pb-8 sm:pt-5 sm:pb-10 border-b  ${className}`}
     >
       {children}
     </div>
@@ -375,7 +375,7 @@ export const Neighbors = ({ area }: { area: Area }) => {
   ];
 
   return (
-    <SectionWrapper id="neighbors">
+    <SectionWrapper id="neighbors" className="border-b lg:border-b-0">
       <SectionTitle title="周辺情報" />
       <Tab tabLabels={tabLabels} contents={contents} />
     </SectionWrapper>
@@ -505,7 +505,7 @@ export const InstagramAds = () => {
   }, []);
 
   return (
-    <SectionWrapper id="about-us">
+    <SectionWrapper id="about-us" className="border-b-0 lg:border-b">
       <SectionTitle title="バンクーバーのお家について" />
       <blockquote
         className="instagram-media"

--- a/frontend/components/features/property/PropertyList.tsx
+++ b/frontend/components/features/property/PropertyList.tsx
@@ -81,7 +81,7 @@ export default function PropertyList({
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-6 gap-2 sm:gap-4 lg:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-4 lg:gap-6">
             <CardArea properties={paginatedProperties} />
           </div>
           <div className="py-5">


### PR DESCRIPTION
## 全体

- [x] 全体の動作確認は完了しているか
- [x] develop へのマージリクエストとなっているか

## frontend

- [x] `npm run build` を実行しエラーは出ていないか

## strapi
Strapiへの変更なし
- [ -] `npm run build`を実行しエラーは出ていないか

## 概要

**以下コンポーネントへ最大幅の設定**
- Propertyカードリスト
- 共通コンポーネント（カードリスト・詳細ページ）
- カテゴリーバー
- ヘッダー
- ブログ詳細
- スケルトン（カードリストと詳細ページ）

以下カードリストの最大表示列数を６→５へ
- PropertyList
- ListPageFrame（共通コンポーネント）
- KistPageSkeleton（共通コンポーネント）

**カテゴリーアイテム　Blog  をカテゴリー２番へ移動**


<!--　
(例)　ブログ一覧・詳細ページ実装
-->

## UI Before / After

比較写真　前者Before / 　後者After
![Screenshot 2025-04-12 at 2 36 19 AM](https://github.com/user-attachments/assets/bdefbc68-da65-4a9e-9ffc-1bae4e29c1ec)
![Screenshot 2025-04-12 at 2 36 06 AM](https://github.com/user-attachments/assets/544af801-481c-440d-9adf-caa68a011cb5)

![Screenshot 2025-04-12 at 2 33 31 AM (2)](https://github.com/user-attachments/assets/7cbcb94e-5a2c-441f-a07e-929bb7b353be)
![Screenshot 2025-04-12 at 2 35 30 AM (2)](https://github.com/user-attachments/assets/0b8b9db8-8bc9-4f22-8f98-f4e9f079d686)

![Screenshot 2025-04-12 at 2 33 49 AM](https://github.com/user-attachments/assets/e5a5e9c3-6192-42bf-ad45-ea11cd045b7b)
![Screenshot 2025-04-12 at 2 33 06 AM](https://github.com/user-attachments/assets/cba30989-8022-4d21-84ce-e9920763d38f)



<!-- UI や振る舞いが変わる場合は before / after のスクショや動画を共有する -->

## 残作業・課題

今回は現段階で使用されてる共通コンポーネントと、今回の変更で影響を受けたブログ詳細ページのみスタイルの適用を行った。
その他共通コンポーネントは各自実装時に確認する必要がある。

また物件詳細ページのコンテンツ表示幅にも影響があるがデザインがないので未対応。
適宜ご確認お願いします。

<!--
(例)　
・フィルター機能未実装
・〇〇について解決したい #1 （ISSUESのリンクを貼る等）
 -->

## 補足

特になし

<!--　あれば補足　-->
