### PR TITLE
Feature/add accessibility

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -82,6 +82,14 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Tabキーフォーカスのあったっているリンクに黒枠を表示する */
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible {
+    @apply focus-visible:outline focus-visible:outline-2 focus-visible:outline-black focus-visible:outline-offset-2;
+  }
 }
 
 /* インスタ埋め込みのwidth設定 */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -73,6 +73,13 @@
   .content-height {
     @apply min-h-[calc(100vh-64px-80px-64px)] lg:min-h-[calc(100vh-80px-80px-68px)] z-0;
   }
+
+  /* cardList コンポーネント専用の focus-visible スタイル */
+  .cardList:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px black;
+    border-radius: 8px;
+  }
 }
 
 @layer base {

--- a/frontend/components/common/Categories.tsx
+++ b/frontend/components/common/Categories.tsx
@@ -160,6 +160,42 @@ function Categories() {
     }
   };
 
+  // 矢印キーでカテゴリー項目を移動（アクセシビリティ対応）
+  const handleArrowKeyNavigation = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const categoryEls =
+      categoryBarRef.current?.querySelectorAll("[data-category]");
+    if (!categoryEls || categoryEls.length === 0) return;
+
+    // 現在フォーカスが当たっている要素のインデックスを調べる
+    let currentIndex = -1;
+    categoryEls.forEach((el, index) => {
+      if (document.activeElement === el) {
+        currentIndex = index;
+      }
+    });
+
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      // まだフォーカスされていなければ最初の要素にフォーカス
+      if (currentIndex === -1) {
+        (categoryEls[0] as HTMLElement).focus();
+      } else {
+        const nextIndex = (currentIndex + 1) % categoryEls.length;
+        (categoryEls[nextIndex] as HTMLElement).focus();
+      }
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      if (currentIndex === -1) {
+        // フォーカスがなければ最後の要素にフォーカス
+        (categoryEls[categoryEls.length - 1] as HTMLElement).focus();
+      } else {
+        const prevIndex =
+          (currentIndex - 1 + categoryEls.length) % categoryEls.length;
+        (categoryEls[prevIndex] as HTMLElement).focus();
+      }
+    }
+  };
+
   // カテゴリー項目からフォーカスが外れた場合、キーボード操作状態をリセット（アクセシビリティ対応）
   const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
     const relatedTarget = e.relatedTarget as HTMLElement | null;
@@ -317,7 +353,8 @@ function Categories() {
         */}
         <div
           tabIndex={30}
-          onKeyDown={handleKeyDown}
+          // onKeyDown={handleKeyDown}
+          onKeyDownCapture={handleArrowKeyNavigation}
           ref={combinedRef}
           className="overflow-hidden"
         >
@@ -338,10 +375,19 @@ function Categories() {
                     categoryRefs.current[item.pathname] = el;
                   }}
                   onClick={() => handleCategoryClick(item.pathname)}
+                  // onKeyDown={(e) => {
+                  //   e.stopPropagation();
+                  //   // 共通の handleEnterKey を使用して Enter キー押下時に handleClick を実行
+                  //   handleEnterKey(e, handleClick);
+                  // }}
+
                   onKeyDown={(e) => {
-                    e.stopPropagation();
-                    // 共通の handleEnterKey を使用して Enter キー押下時に handleClick を実行
-                    handleEnterKey(e, handleClick);
+                    if (e.key === "Enter") {
+                      // Enter キーの場合は既存の動作を実行して伝播を止める
+                      e.stopPropagation();
+                      handleEnterKey(e, handleClick);
+                    }
+                    // 矢印キーの場合は伝播を止めない（もしくは、ここで独自に処理しても良い）
                   }}
                   onBlur={handleBlur}
                   className={`min-w-[80px] ${

--- a/frontend/components/common/Categories.tsx
+++ b/frontend/components/common/Categories.tsx
@@ -353,8 +353,7 @@ function Categories() {
         */}
         <div
           tabIndex={30}
-          // onKeyDown={handleKeyDown}
-          onKeyDownCapture={handleArrowKeyNavigation}
+          onKeyDownCapture={handleArrowKeyNavigation} //矢印キーでの左右移動
           ref={combinedRef}
           className="overflow-hidden"
         >
@@ -375,19 +374,11 @@ function Categories() {
                     categoryRefs.current[item.pathname] = el;
                   }}
                   onClick={() => handleCategoryClick(item.pathname)}
-                  // onKeyDown={(e) => {
-                  //   e.stopPropagation();
-                  //   // 共通の handleEnterKey を使用して Enter キー押下時に handleClick を実行
-                  //   handleEnterKey(e, handleClick);
-                  // }}
-
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
-                      // Enter キーの場合は既存の動作を実行して伝播を止める
                       e.stopPropagation();
                       handleEnterKey(e, handleClick);
                     }
-                    // 矢印キーの場合は伝播を止めない（もしくは、ここで独自に処理しても良い）
                   }}
                   onBlur={handleBlur}
                   className={`min-w-[80px] ${
@@ -401,7 +392,7 @@ function Categories() {
                     name={item.name}
                     pathname={item.pathname}
                     selected={pathname === item.pathname}
-                    onClick={handleClick} // 変更: onClick ハンドラを CategoryBox に渡す
+                    onClick={handleClick}
                   />
                 </div>
               );

--- a/frontend/components/common/Categories.tsx
+++ b/frontend/components/common/Categories.tsx
@@ -23,6 +23,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import Image from "next/image";
+import { handleEnterKey } from "@/utils/accessibility/a11y";
 
 export interface Category {
   name: string;
@@ -117,11 +118,56 @@ export const CATEGORY_LIST: Category[] = [
  * カテゴリーコンポーネント
  */
 function Categories() {
+  const router = useRouter();
+
   const [emblaRef, emblaApi] = useEmblaCarousel({
     align: "start", // スライドを左端から配置
     containScroll: "trimSnaps", // スクロール範囲をスナップ位置に制限
     dragFree: true, // 指やマウスで自由にスクロール可能にする
   });
+
+  // 複数の ref を統合するためのユーティリティ関数を追加
+  function useCombinedRefs<T>(
+    ...refs: (React.Ref<T> | undefined)[]
+  ): React.RefCallback<T> {
+    return (element: T) => {
+      refs.forEach((ref) => {
+        if (typeof ref === "function") {
+          ref(element);
+        } else if (ref && typeof ref === "object") {
+          (ref as React.MutableRefObject<T | null>).current = element;
+        }
+      });
+    };
+  }
+
+  // カテゴリーバーへの参照を追加し、emblaRef と統合しクセシビリティ用の操作を追加
+  const categoryBarRef = useRef<HTMLDivElement>(null);
+  const combinedRef = useCombinedRefs<HTMLDivElement>(emblaRef, categoryBarRef);
+
+  // キーボード操作のための状態（カテゴリー内のキーボードフォーカス管理用）
+  const [isInsideFocusActive, setIsInsideFocusActive] = useState(false);
+
+  // Enter キー押下時にカテゴリー内へフォーカスを移す（アクセシビリティ対応）
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter") {
+      setIsInsideFocusActive(true);
+      const categoryEls =
+        categoryBarRef.current?.querySelectorAll("[data-category]");
+      if (categoryEls && categoryEls.length > 0) {
+        (categoryEls[0] as HTMLElement).focus();
+      }
+    }
+  };
+
+  // カテゴリー項目からフォーカスが外れた場合、キーボード操作状態をリセット（アクセシビリティ対応）
+  const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    const relatedTarget = e.relatedTarget as HTMLElement | null;
+    const stillInside = relatedTarget?.dataset?.category !== undefined;
+    if (!stillInside) {
+      setIsInsideFocusActive(false);
+    }
+  };
 
   // スクロールボタンの有効/無効状態を管理する
   const [prevBtnEnabled, setPrevBtnEnabled] = useState(false);
@@ -266,34 +312,62 @@ function Categories() {
     // >
     <div className="w-full flex justify-center">
       <div className="relative base-px py-2 h-20  ">
-        <div className="overflow-hidden" ref={emblaRef}>
+        {/*
+          combinedRef と tabIndex、onKeyDown を追加してキーボードでの操作を可能に
+        */}
+        <div
+          tabIndex={30}
+          onKeyDown={handleKeyDown}
+          ref={combinedRef}
+          className="overflow-hidden"
+        >
           <div className="flex">
-            {CATEGORY_LIST.map((item, index) => (
-              <div
-                key={item.name}
-                ref={(el) => {
-                  categoryRefs.current[item.pathname] = el;
-                }}
-                onClick={() => handleCategoryClick(item.pathname)}
-                className={`${index === 0 ? "ml-0" : "ml-2 lg:ml-3"} ${
-                  index === CATEGORY_LIST.length - 1 ? "mr-0" : "mr-2 lg:mr-3"
-                }`}
-              >
-                <CategoryBox
-                  icon={item.icon}
-                  name={item.name}
-                  pathname={item.pathname}
-                  selected={pathname === item.pathname}
-                />
-              </div>
-            ))}
+            {CATEGORY_LIST.map((item, index) => {
+              // 変更: キーボード操作用のコールバックを定義 (Enter キー押下時にページ遷移させる)
+              const handleClick = () => {
+                router.push(item.pathname);
+              };
+
+              return (
+                <div
+                  data-category
+                  key={item.name}
+                  // isInsideFocusActive によって tabIndex を切り替え、キーボードフォーカス可能にする
+                  tabIndex={isInsideFocusActive ? 31 + index : -1}
+                  ref={(el) => {
+                    categoryRefs.current[item.pathname] = el;
+                  }}
+                  onClick={() => handleCategoryClick(item.pathname)}
+                  onKeyDown={(e) => {
+                    e.stopPropagation();
+                    // 共通の handleEnterKey を使用して Enter キー押下時に handleClick を実行
+                    handleEnterKey(e, handleClick);
+                  }}
+                  onBlur={handleBlur}
+                  className={`min-w-[80px] ${
+                    index === 0 ? "ml-0" : "ml-2 lg:ml-3"
+                  } ${
+                    index === CATEGORY_LIST.length - 1 ? "mr-0" : "mr-2 lg:mr-3"
+                  }`}
+                >
+                  <CategoryBox
+                    icon={item.icon}
+                    name={item.name}
+                    pathname={item.pathname}
+                    selected={pathname === item.pathname}
+                    onClick={handleClick} // 変更: onClick ハンドラを CategoryBox に渡す
+                  />
+                </div>
+              );
+            })}
           </div>
         </div>
         {/* スクロールボタン PCで表示 */}
         <div className="hidden lg:block">
           {prevBtnEnabled && (
             <button
-              className="absolute left-10 xl:left-20 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
+              tabIndex={60}
+              className="absolute left-20 2xl:left-0 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
               onClick={scrollPrev}
             >
               <ChevronLeft size={18} />
@@ -301,7 +375,8 @@ function Categories() {
           )}
           {nextBtnEnabled && (
             <button
-              className="absolute right-10 xl:right-20 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
+              tabIndex={61}
+              className="absolute right-20  2xl:right-0 top-1/2 transform -translate-y-1/2 border bg-white p-1 rounded-full shadow-md z-10"
               onClick={scrollNext}
             >
               <ChevronRight size={18} />
@@ -319,11 +394,13 @@ function CategoryBox({
   name,
   pathname,
   selected,
+  onClick,
 }: {
   icon: LucideIcon | null;
   name: string;
   pathname: string;
   selected: boolean;
+  onClick: () => void;
 }) {
   const router = useRouter();
 

--- a/frontend/components/common/PaginationList.tsx
+++ b/frontend/components/common/PaginationList.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/pagination";
 import { createQueryString } from "@/utils/queryStringHelper";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { handleEnterKey } from "@/utils/accessibility/a11y";
 
 interface PaginationListProps {
   currentPage: number;
@@ -39,7 +40,11 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {currentPage > 1 && (
           <PaginationItem>
             <PaginationPrevious
+              tabIndex={200}
               onClick={() => handlePageChange(currentPage - 1)}
+              onKeyDown={(e) =>
+                handleEnterKey(e, () => handlePageChange(currentPage - 1))
+              }
             />
           </PaginationItem>
         )}
@@ -47,7 +52,9 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {currentPage > 1 && (
           <PaginationItem>
             <PaginationLink
+              tabIndex={201}
               onClick={() => handlePageChange(1)}
+              onKeyDown={(e) => handleEnterKey(e, () => handlePageChange(1))}
               isActive={currentPage === 1}
             >
               1
@@ -65,7 +72,13 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {/* previous page number */}
         {currentPage > 2 && (
           <PaginationItem>
-            <PaginationLink onClick={() => handlePageChange(currentPage - 1)}>
+            <PaginationLink
+              tabIndex={202}
+              onClick={() => handlePageChange(currentPage - 1)}
+              onKeyDown={(e) =>
+                handleEnterKey(e, () => handlePageChange(currentPage - 1))
+              }
+            >
               {currentPage - 1}
             </PaginationLink>
           </PaginationItem>
@@ -74,6 +87,7 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {/* current page */}
         <PaginationItem>
           <PaginationLink
+            tabIndex={203}
             className="bg-bloom-lightBlue text-bloom-blue border border-bloom-blue"
             isActive
           >
@@ -84,7 +98,13 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {/* next page number */}
         {currentPage < totalPage - 1 && (
           <PaginationItem>
-            <PaginationLink onClick={() => handlePageChange(currentPage + 1)}>
+            <PaginationLink
+              tabIndex={204}
+              onClick={() => handlePageChange(currentPage + 1)}
+              onKeyDown={(e) =>
+                handleEnterKey(e, () => handlePageChange(currentPage + 1))
+              }
+            >
               {currentPage + 1}
             </PaginationLink>
           </PaginationItem>
@@ -101,7 +121,11 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {totalPage > 1 && currentPage < totalPage && (
           <PaginationItem>
             <PaginationLink
+              tabIndex={205}
               onClick={() => handlePageChange(totalPage)}
+              onKeyDown={(e) =>
+                handleEnterKey(e, () => handlePageChange(totalPage))
+              }
               isActive={currentPage === totalPage}
             >
               {totalPage}
@@ -112,7 +136,13 @@ function PaginationList({ currentPage, totalPage }: PaginationListProps) {
         {/* next page */}
         {currentPage < totalPage && (
           <PaginationItem>
-            <PaginationNext onClick={() => handlePageChange(currentPage + 1)} />
+            <PaginationNext
+              tabIndex={206}
+              onClick={() => handlePageChange(currentPage + 1)}
+              onKeyDown={(e) =>
+                handleEnterKey(e, () => handlePageChange(currentPage + 1))
+              }
+            />
           </PaginationItem>
         )}
       </PaginationContent>

--- a/frontend/components/common/SearchBar.tsx
+++ b/frontend/components/common/SearchBar.tsx
@@ -48,6 +48,7 @@ function SearchBar() {
   return (
     <div className="relative w-full">
       <Input
+        tabIndex={11}
         type="search"
         placeholder="キーワード検索"
         className="w-full pr-14 pl-5 text-xs rounded-full shadow-sm" // 右側にアイコン分の余白を確保
@@ -55,6 +56,8 @@ function SearchBar() {
         onChange={(e) => handleKeywordChange(e)}
       />
       <Button
+        tabIndex={12}
+        aria-label="検索する"
         type="button"
         variant="outline"
         className="absolute right-1.5 top-1/2 transform -translate-y-1/2 bg-bloom-blue flex items-center justify-center rounded-full w-8 h-8 p-0 border-0"

--- a/frontend/components/common/Sort.tsx
+++ b/frontend/components/common/Sort.tsx
@@ -66,7 +66,11 @@ function Sort({ sortOptions }: { sortOptions: optionType[] }) {
       onValueChange={handleChangeSort}
       onOpenChange={(open) => setIsOpen(open)}
     >
-      <SelectTrigger className="flex items-center justify-center gap-1 border-none px-0">
+      <SelectTrigger
+        tabIndex={71}
+        aria-label="ソートドロップダウンメニュー"
+        className="flex items-center justify-center gap-1 border-none px-0"
+      >
         <span className="text-sm">表示: {selectedLabel}</span>
         {isOpen ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
       </SelectTrigger>

--- a/frontend/components/common/frame/CardFrame.tsx
+++ b/frontend/components/common/frame/CardFrame.tsx
@@ -2,6 +2,7 @@
 import Image from "next/image";
 import { ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import { handleEnterKey } from "@/utils/accessibility/a11y";
 
 interface CardFrameProps {
   linkTo: string;
@@ -10,6 +11,8 @@ interface CardFrameProps {
   badgeMessage?: string;
   badgeStyle?: string;
   cardContent: ReactNode;
+  tabIndex?: number;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
 /**
@@ -29,6 +32,7 @@ function CardFrame({
   badgeMessage,
   badgeStyle = "bg-white",
   cardContent,
+  tabIndex,
 }: CardFrameProps) {
   const router = useRouter();
 
@@ -43,7 +47,12 @@ function CardFrame({
   };
 
   return (
-    <div className="relative cursor-pointer" onClick={goToDetail}>
+    <div
+      tabIndex={tabIndex}
+      className="relative cursor-pointer"
+      onClick={goToDetail}
+      onKeyDown={(e) => handleEnterKey(e, goToDetail)}
+    >
       {/* 画像 */}
       <div className="relative z-0 w-full rounded-lg aspect-[9/8]">
         {imageSrc ? (

--- a/frontend/components/common/frame/CardFrame.tsx
+++ b/frontend/components/common/frame/CardFrame.tsx
@@ -49,7 +49,7 @@ function CardFrame({
   return (
     <div
       tabIndex={tabIndex}
-      className="relative cursor-pointer"
+      className="relative cursor-pointer cardList"
       onClick={goToDetail}
       onKeyDown={(e) => handleEnterKey(e, goToDetail)}
     >

--- a/frontend/components/common/frame/ListPageFrame.tsx
+++ b/frontend/components/common/frame/ListPageFrame.tsx
@@ -65,7 +65,7 @@ function ListPageFrame({
             <p>条件に一致する物件が見つかりませんでした。</p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-4 lg:gap-6">
+          <div className="cardList grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-4 lg:gap-6">
             {cardArea}
           </div>
         )}

--- a/frontend/components/common/header/Header.tsx
+++ b/frontend/components/common/header/Header.tsx
@@ -125,6 +125,7 @@ const Header = () => {
       <div className="base-px relative z-50 w-screen flex items-center justify-between gap-4">
         {/* Bloomロゴ */}
         <Link
+          tabIndex={10}
           href="/properties"
           className="flex items-center gap-2 whitespace-nowrap cursor-pointer w-36 lg:w-48"
         >
@@ -177,7 +178,10 @@ const NavMenu = () => {
         }
       }}
     >
-      <SelectTrigger className="w-12 h-12 cursor-pointer flex items-center justify-end border-none p-0 hover:text-bloom-gray">
+      <SelectTrigger
+        tabIndex={13}
+        className="w-12 h-12 cursor-pointer flex items-center justify-end border-none p-0 hover:text-bloom-gray"
+      >
         <Menu size={22} />
       </SelectTrigger>
       <SelectContent position={undefined}>

--- a/frontend/components/common/pagination/PaginationComponent.tsx
+++ b/frontend/components/common/pagination/PaginationComponent.tsx
@@ -36,6 +36,7 @@ function PaginationComponent({ pagination }: { pagination: PaginationType }) {
         <PaginationItem>
           {page > 1 && (
             <PaginationPrevious
+              tabIndex={200}
               href="#"
               onClick={() => handlePageChange(page - 1)}
             />
@@ -63,6 +64,7 @@ function PaginationComponent({ pagination }: { pagination: PaginationType }) {
           return (
             <PaginationItem key={pageNumber}>
               <PaginationLink
+                tabIndex={201 + pageNumber}
                 href="#"
                 isActive={pageNumber === page}
                 onClick={() => handlePageChange(pageNumber)}
@@ -89,6 +91,7 @@ function PaginationComponent({ pagination }: { pagination: PaginationType }) {
         {pageCount > 5 && page < pageCount - 2 && (
           <PaginationItem>
             <PaginationLink
+              tabIndex={298}
               href="#"
               onClick={() => handlePageChange(pageCount)}
             >
@@ -101,6 +104,7 @@ function PaginationComponent({ pagination }: { pagination: PaginationType }) {
         <PaginationItem>
           {page < pageCount && (
             <PaginationNext
+              tabIndex={299}
               href="#"
               onClick={() => handlePageChange(page + 1)}
             />

--- a/frontend/components/features/blog/BlogList.tsx
+++ b/frontend/components/features/blog/BlogList.tsx
@@ -33,16 +33,20 @@ function CardArea({ data }: { data: Blog[] }) {
   return (
     <>
       {/* マップで並べる */}
-      {data.map((blog) => (
-        <CardFrame
-          key={blog.documentId}
-          linkTo={`/blogs/${blog.documentId.toString()}`} // 詳細画面の遷移先パス
-          imageSrc={blog.coverImage.url} // カードの画像
-          imageAlt={blog.title} // 画像の説明文
-          cardContent={<CardContent blog={blog} />} // 画像下にくる部分　（別途作成）
-          badgeMessage={blog.category?.categoryName} // 左上のバッヂ
-        />
-      ))}
+      {data.map((blog, index: number) => {
+        const tabIndex = 100 + index; // 各ページで100からスタート
+        return (
+          <CardFrame
+            tabIndex={tabIndex}
+            key={blog.documentId}
+            linkTo={`/blogs/${blog.documentId.toString()}`} // 詳細画面の遷移先パス
+            imageSrc={blog.coverImage.url} // カードの画像
+            imageAlt={blog.title} // 画像の説明文
+            cardContent={<CardContent blog={blog} />} // 画像下にくる部分　（別途作成）
+            badgeMessage={blog.category?.categoryName} // 左上のバッヂ
+          />
+        );
+      })}
     </>
   );
 }

--- a/frontend/components/features/property/FilterDialog.tsx
+++ b/frontend/components/features/property/FilterDialog.tsx
@@ -188,6 +188,8 @@ export function FilterDialog({ filteredPropertiesNumbers }: FilterDialogProps) {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild className="">
         <Button
+          tabIndex={70}
+          aria-label="フィルター"
           variant="outline"
           className="flex items-center justify-center gap-2 sm:px-4 p-0 min-w-10 min-h-10 rounded-full hover:border-bloom-blue hover:text-bloom-blue hover:bg-bloom-lightBlue"
         >

--- a/frontend/components/features/property/PropertyList.tsx
+++ b/frontend/components/features/property/PropertyList.tsx
@@ -151,6 +151,7 @@ const PropertyCard = ({
       badgeStyle={labelColor}
       cardContent={<CardContent property={property} />}
       tabIndex={tabIndex}
+      
     />
   );
 };

--- a/frontend/components/features/property/PropertyList.tsx
+++ b/frontend/components/features/property/PropertyList.tsx
@@ -101,11 +101,18 @@ export default function PropertyList({
 const CardArea = ({ properties }: { properties: NotionProperty[] }) => {
   return (
     <>
-      {properties.map((p: NotionProperty) => {
+      {properties.map((p: NotionProperty, index: number) => {
         const property: PropertyCardData | null = formatPropertyCardData(p);
+        const tabIndex = 100 + index; // 各ページで100からスタート
 
         if (property !== null) {
-          return <PropertyCard key={property.id} property={property} />;
+          return (
+            <PropertyCard
+              tabIndex={tabIndex}
+              key={property.id}
+              property={property}
+            />
+          );
         }
       })}
     </>
@@ -116,7 +123,13 @@ const CardArea = ({ properties }: { properties: NotionProperty[] }) => {
  * 物件一覧ページのカード
  * ＠params property {PropertyCardData}
  */
-const PropertyCard = ({ property }: { property: PropertyCardData }) => {
+const PropertyCard = ({
+  property,
+  tabIndex,
+}: {
+  property: PropertyCardData;
+  tabIndex: number;
+}) => {
   /* 募集中の物件のみ「入居者募集中」 or 「即入居可能」のラベル */
   const labelMessage =
     property.status === "入居者募集中" || property.status === "即入居可能"
@@ -137,6 +150,7 @@ const PropertyCard = ({ property }: { property: PropertyCardData }) => {
       badgeMessage={labelMessage}
       badgeStyle={labelColor}
       cardContent={<CardContent property={property} />}
+      tabIndex={tabIndex}
     />
   );
 };

--- a/frontend/utils/accessibility/a11y.ts
+++ b/frontend/utils/accessibility/a11y.ts
@@ -1,0 +1,9 @@
+//キーボード操作での「Enter」キー押下で何かの動作をトリガーしたい時の共通ファンクション
+export const handleEnterKey = (
+  e: React.KeyboardEvent<HTMLElement>,
+  callback: () => void
+) => {
+  if (e.key === "Enter") {
+    callback();
+  }
+};


### PR DESCRIPTION
## 全体

- [ ] 全体の動作確認は完了しているか
- [ ] develop へのマージリクエストとなっているか

## frontend

- [ ] `npm run build` を実行しエラーは出ていないか

## strapi
今回変更なし
- [ ] `npm run build`を実行しエラーは出ていないか

## 概要
共通コンポーネントへTabindexなどアクセシビリティ機能追加
<!--　
(例)　ブログ一覧・詳細ページ実装
-->

## UI Before / After
Tabキーでフォーカス中のリンク/カードに黒枠が表示される（画像はカード１枚目にフォーカス）
![Screenshot 2025-04-14 at 7 19 05 PM](https://github.com/user-attachments/assets/cba1b8a4-3219-4a9b-85d8-3f0582d9788e)


<!-- UI や振る舞いが変わる場合は before / after のスクショや動画を共有する -->

## 残作業・課題
共通コンポーネントのみに実装。
その他詳細ページは各自担当が実装すること。
<!--
(例)　
・フィルター機能未実装
・〇〇について解決したい #1 （ISSUESのリンクを貼る等）
 -->

## 補足
とくになし
<!--　あれば補足　-->
